### PR TITLE
fix: address critical financial-correctness findings from pre-OSS audit

### DIFF
--- a/discipline_hr/discipline_hr/doctype/attendance_penalty_policy/attendance_penalty_policy.json
+++ b/discipline_hr/discipline_hr/doctype/attendance_penalty_policy/attendance_penalty_policy.json
@@ -12,17 +12,18 @@
  ],
  "fields": [
   {
+   "description": "Choose how penalties are calculated.<br><b>Factor</b>: <code>deducted_minutes_factor &times; minute_rate &times; penalty_minutes</code> (e.g. 2.0 doubles each penalty minute against the employee's per-minute salary).<br><b>Fixed Per Hour</b>: flat <code>rate_per_hour / 60 &times; penalty_minutes</code> (e.g. 50 currency/hour regardless of salary).<br><b>Penalty Matrix</b>: escalating % of the daily rate per violation count in the period (e.g. 1st = 50% of a day, 2nd = 100%, 3rd = 150%).",
    "fieldname": "penalty_type",
    "fieldtype": "Select",
    "in_list_view": 1,
-   "description": "Factor: multiply penalty minutes by a factor and minute rate. Fixed Per Hour: flat rate per hour of penalty. Penalty Matrix: escalating % of daily rate per violation count.",
+   "in_standard_filter": 1,
    "label": "Penalty Type",
    "options": "\nFactor\nFixed Per Hour\nPenalty Matrix",
    "reqd": 1
   },
   {
    "depends_on": "eval:doc.penalty_type === \"Factor\"",
-   "description": "In minutes",
+   "description": "Multiplier applied to each penalty minute. Formula: <code>factor &times; minute_rate &times; penalty_minutes</code>, where <code>minute_rate = base_salary / month_days / working_minutes_per_day</code>. Use 1.0 for a straight per-minute deduction; values above 1.0 amplify the penalty.",
    "fieldname": "deducted_minutes_factor",
    "fieldtype": "Float",
    "label": "Deducted Factor",
@@ -38,6 +39,7 @@
   },
   {
    "depends_on": "eval:doc.penalty_type === \"Fixed Per Hour\"",
+   "description": "Hourly deduction amount (currency). Internally divided by 60 to get a per-minute rate: <code>rate_per_hour / 60 &times; penalty_minutes</code>. Independent of employee salary.",
    "fieldname": "rate_per_hour",
    "fieldtype": "Currency",
    "label": "Rate Per Hour",

--- a/discipline_hr/discipline_hr/doctype/attendance_permissions/attendance_permissions.json
+++ b/discipline_hr/discipline_hr/doctype/attendance_permissions/attendance_permissions.json
@@ -44,6 +44,8 @@
   {
    "fieldname": "date",
    "fieldtype": "Date",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Date",
    "read_only_depends_on": "eval:doc.status !== 'Pending'",
    "reqd": 1
@@ -72,6 +74,7 @@
    "read_only_depends_on": "eval:doc.status !== 'Pending'"
   },
   {
+   "description": "Late or early minutes after subtracting the shift grace period. Negative values are clamped to zero.",
    "fieldname": "minutes",
    "fieldtype": "Int",
    "in_list_view": 1,
@@ -92,6 +95,7 @@
   },
   {
    "default": "0",
+   "description": "Set automatically when this permission was created by the attendance pipeline rather than by a user.",
    "fieldname": "auto_created",
    "fieldtype": "Check",
    "hidden": 1,
@@ -99,6 +103,7 @@
    "read_only": 1
   },
   {
+   "bold": 1,
    "default": "Pending",
    "fieldname": "status",
    "fieldtype": "Select",
@@ -114,6 +119,7 @@
    "label": "Error Log"
   },
   {
+   "description": "Populated when the auto-processing pipeline failed. Click **Retry** on the form to re-run.",
    "fieldname": "error_log",
    "fieldtype": "Small Text",
    "label": "Error Log",

--- a/discipline_hr/discipline_hr/doctype/discipline_hr_settings/discipline_hr_settings.json
+++ b/discipline_hr/discipline_hr/doctype/discipline_hr_settings/discipline_hr_settings.json
@@ -8,9 +8,10 @@
   "section_break_policies",
   "attendance_penalty_policy",
   "absence_penalty_policy",
-  "salary_basis",
   "column_break_policies",
   "salary_component",
+  "section_break_salary_calc",
+  "salary_basis",
   "month_days",
   "section_break_automation",
   "auto_process_attendance_permission",
@@ -56,11 +57,17 @@
   },
   {
    "default": "30",
-   "description": "Number of days in a month used to compute the employee daily rate (base / month days). Default is 30.",
+   "description": "Working days per month used to derive the daily rate from base salary (<code>daily_rate = base / month_days</code>). Common values: 22 (working days), 26 (six-day week), 30 (calendar days). Default is 30.",
    "fieldname": "month_days",
    "fieldtype": "Int",
    "label": "Month Days",
    "non_negative": 1
+  },
+  {
+   "description": "Inputs for converting penalty minutes into a deduction amount. Used by the Factor penalty type and the daily-rate basis for the Penalty Matrix.",
+   "fieldname": "section_break_salary_calc",
+   "fieldtype": "Section Break",
+   "label": "Salary Calculation"
   },
   {
    "fieldname": "section_break_automation",
@@ -113,7 +120,7 @@
   },
   {
    "default": "0",
-   "description": "If checked, penalties are processed directly from Attendance without creating an Attendance Permissions record.",
+   "description": "<b>Unchecked</b>: every late/early event creates an Attendance Permission first; HR reviews and accepts before a penalty is generated.<br><b>Checked</b>: penalties are processed directly from Attendance, skipping the HR review step. Use this when you trust the pipeline and want immediate enforcement.",
    "fieldname": "split_permissions_and_penalties",
    "fieldtype": "Check",
    "label": "Split Permissions and Penalties"

--- a/discipline_hr/discipline_hr/doctype/discipline_penalty/discipline_penalty.json
+++ b/discipline_hr/discipline_hr/doctype/discipline_penalty/discipline_penalty.json
@@ -95,8 +95,10 @@
    "reqd": 1
   },
   {
+   "bold": 1,
    "fieldname": "status",
    "fieldtype": "Select",
+   "in_standard_filter": 1,
    "label": "Status",
    "options": "\nAuto Processed\nPending\nProcessed\nRejected",
    "read_only": 1
@@ -107,6 +109,7 @@
    "label": "Violation Details"
   },
   {
+   "description": "1-based count of prior penalties for this employee inside the current period.",
    "fieldname": "violation_number",
    "fieldtype": "Int",
    "in_list_view": 1,
@@ -143,6 +146,7 @@
    "read_only": 1
   },
   {
+   "description": "Computed by the resolved Attendance Penalty Policy. Read-only.",
    "fieldname": "section_break_penalty",
    "fieldtype": "Section Break",
    "label": "Penalty Calculation"
@@ -170,6 +174,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "description": "Resolved from policy or shift configuration. Used to create the deduction Additional Salary entry.",
    "fieldname": "salary_component",
    "fieldtype": "Link",
    "label": "Salary Component",
@@ -190,6 +195,7 @@
   },
   {
    "default": "0",
+   "description": "When checked, an Additional Salary deduction is created automatically on submit.",
    "fieldname": "auto_create_salary",
    "fieldtype": "Check",
    "label": "Auto Create Salary",
@@ -221,6 +227,7 @@
    "label": "Connections"
   },
   {
+   "description": "Populated when a previous processing attempt failed. Use the **Retry** button to re-run the pipeline.",
    "fieldname": "error_log",
    "fieldtype": "Small Text",
    "label": "Error",

--- a/discipline_hr/discipline_hr/doctype/discipline_penalty/discipline_penalty.py
+++ b/discipline_hr/discipline_hr/doctype/discipline_penalty/discipline_penalty.py
@@ -98,9 +98,27 @@ class DisciplinePenalty(Document):
         if not self.salary_component:
             _log("warning", "additional_salary_skipped_no_component", penalty=str(self.name))
             return
-        if frappe.db.exists("Additional Salary", {"custom_discipline_penalty": self.name}):
-            self.db_set("error_log", None)
-            _log("info", "additional_salary_exists", penalty=self.name)
+        existing = frappe.db.get_value(
+            "Additional Salary",
+            {"custom_discipline_penalty": self.name, "docstatus": ("!=", 2)},
+            ["name", "docstatus"],
+        )
+        if existing:
+            existing_name, existing_docstatus = existing
+            try:
+                config = self._get_discipline_hr_settings()
+                if existing_docstatus == 0 and config.auto_submit_additional_salary == 1:
+                    frappe.get_doc("Additional Salary", existing_name).submit()
+                self.db_set("error_log", None)
+                _log("info", "additional_salary_exists", penalty=self.name, additional_salary=existing_name)
+            except Exception as e:
+                _log(
+                    "exception",
+                    "additional_salary_retry_submit_failed",
+                    penalty=self.name,
+                    additional_salary=existing_name,
+                )
+                self.db_set("error_log", str(e))
             return
         try:
             config = self._get_discipline_hr_settings()
@@ -143,12 +161,20 @@ class DisciplinePenalty(Document):
     def _get_employee_daily_rate(self):
         """Get employee daily rate from Salary Structure Assignment.
 
+        Filters by ``from_date <= violation_date`` and picks the latest such
+        assignment, so retroactive raises do not silently rewrite the amount of
+        a historical penalty.
+
         Uses `salary_basis` setting to determine whether the rate
         is computed from base salary only or total (base + variable).
         """
         assignment = frappe.db.get_value(
             "Salary Structure Assignment",
-            {"employee": self.employee, "docstatus": 1},
+            {
+                "employee": self.employee,
+                "docstatus": 1,
+                "from_date": ("<=", self.violation_date or today()),
+            },
             ["base", "variable"],
             order_by="from_date desc",
         )

--- a/discipline_hr/discipline_hr/doctype/discipline_penalty/test_discipline_penalty.py
+++ b/discipline_hr/discipline_hr/doctype/discipline_penalty/test_discipline_penalty.py
@@ -375,8 +375,8 @@ class TestDisciplinePenalty(TestCase):
 
     @patch(f"{MODULE}.DisciplinePenalty._get_discipline_hr_settings")
     @patch(f"{MODULE}.frappe.get_doc")
-    @patch(f"{MODULE}.frappe.db.exists")
-    def test_discipline_penalty_retry_happy_path(self, mock_exists, mock_get_doc, mock_settings):
+    @patch(f"{MODULE}.frappe.db.get_value")
+    def test_discipline_penalty_retry_happy_path(self, mock_get_value, mock_get_doc, mock_settings):
         """Retry creates an Additional Salary and clears the stale error."""
         # Arrange
         self.penalty.name = "DP-0001"
@@ -384,7 +384,7 @@ class TestDisciplinePenalty(TestCase):
         self.penalty.salary_component = "Basic"
         self.penalty.violation_date = "2026-01-01"
         self.penalty.error_log = "some old error"
-        mock_exists.return_value = None  # no AS exists → proceed to create
+        mock_get_value.return_value = None  # no non-cancelled AS exists → proceed to create
         mock_settings.return_value.auto_submit_additional_salary = 0
 
         # Act
@@ -405,16 +405,18 @@ class TestDisciplinePenalty(TestCase):
             if call_args[0] == "error_log" and call_args[1] is not None:
                 self.fail(f"db_set called with non-None error during retry: {call_args}")
 
+    @patch(f"{MODULE}.DisciplinePenalty._get_discipline_hr_settings")
     @patch(f"{MODULE}._log")
-    @patch(f"{MODULE}.frappe.db.exists")
-    def test_retry_duplicate_guard(self, mock_exists, mock_logger):
-        """If an Additional Salary already exists, retry clears the error and skips creation."""
+    @patch(f"{MODULE}.frappe.db.get_value")
+    def test_retry_duplicate_guard_submitted_as(self, mock_get_value, mock_logger, mock_settings):
+        """A submitted Additional Salary trips the guard, error cleared, no new doc created."""
         # Arrange
         self.penalty.name = "DP-0001"
         self.penalty.penalty_amount = 100
         self.penalty.salary_component = "Basic"
         self.penalty.error_log = "some old error"
-        mock_exists.return_value = "AS-0001"  # duplicate guard trips
+        mock_get_value.return_value = ("AS-0001", 1)  # submitted AS exists
+        mock_settings.return_value.auto_submit_additional_salary = 1
 
         # Act
         with patch.object(self.penalty, "db_set") as mock_db_set:
@@ -422,4 +424,53 @@ class TestDisciplinePenalty(TestCase):
 
         # Assert
         mock_db_set.assert_any_call("error_log", None)
-        mock_logger.assert_called_with("info", "additional_salary_exists", penalty=self.penalty.name)
+        mock_logger.assert_called_with(
+            "info",
+            "additional_salary_exists",
+            penalty=self.penalty.name,
+            additional_salary="AS-0001",
+        )
+
+    @patch(f"{MODULE}.DisciplinePenalty._get_discipline_hr_settings")
+    @patch(f"{MODULE}.frappe.get_doc")
+    @patch(f"{MODULE}.frappe.db.get_value")
+    def test_retry_submits_stuck_draft_additional_salary(self, mock_get_value, mock_get_doc, mock_settings):
+        """A draft AS from a failed submit gets submitted on retry, not silently skipped."""
+        # Arrange
+        self.penalty.name = "DP-0001"
+        self.penalty.penalty_amount = 100
+        self.penalty.salary_component = "Basic"
+        self.penalty.error_log = "submit failed earlier"
+        mock_get_value.return_value = ("AS-0001", 0)  # draft AS exists
+        mock_settings.return_value.auto_submit_additional_salary = 1
+        draft_doc = MagicMock()
+        mock_get_doc.return_value = draft_doc
+
+        # Act
+        with patch.object(self.penalty, "db_set"):
+            self.penalty.retry()
+
+        # Assert: existing draft was fetched and submit() was called on it
+        mock_get_doc.assert_called_with("Additional Salary", "AS-0001")
+        draft_doc.submit.assert_called_once()
+
+    @patch(f"{MODULE}.frappe.get_cached_doc")
+    @patch(f"{MODULE}.frappe.db.get_value")
+    def test_get_employee_daily_rate_filters_by_violation_date(self, mock_db_get_value, mock_get_cached_doc):
+        """SSA lookup must filter by from_date <= violation_date so retro-raises don't change history."""
+        # Arrange
+        self.penalty.violation_date = "2026-01-15"
+        mock_db_get_value.return_value = (3000, 0)
+        mock_config = MagicMock()
+        mock_config.month_days = 30
+        mock_config.salary_basis = "Base"
+        mock_get_cached_doc.return_value = mock_config
+
+        # Act
+        self.penalty._get_employee_daily_rate()
+
+        # Assert: filter must include from_date <= violation_date
+        filters = mock_db_get_value.call_args.args[1]
+        self.assertEqual(
+            filters["from_date"], ("<=", "2026-01-15"), "SSA query must filter by from_date <= violation_date"
+        )

--- a/discipline_hr/discipline_hr/doctype/employee_grace_ledger/employee_grace_ledger.json
+++ b/discipline_hr/discipline_hr/doctype/employee_grace_ledger/employee_grace_ledger.json
@@ -30,6 +30,7 @@
  ],
  "fields": [
   {
+   "bold": 1,
    "fieldname": "employee",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -68,6 +69,12 @@
    "fieldtype": "Column Break"
   },
   {
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "label": "Date",
+   "read_only": 1
+  },
+  {
    "fieldname": "period_start",
    "fieldtype": "Date",
    "label": "Period Start",
@@ -80,6 +87,7 @@
    "read_only": 1
   },
   {
+   "description": "Total grace minutes allotted to this employee for the period (from Shift Type).",
    "fieldname": "allowed_minutes",
    "fieldtype": "Int",
    "label": "Allowed Minutes",
@@ -91,6 +99,7 @@
    "label": "Grace Consumption"
   },
   {
+   "description": "Grace remaining at the moment this attendance event was processed.",
    "fieldname": "remaining_minutes_before_consume",
    "fieldtype": "Int",
    "in_list_view": 1,
@@ -98,6 +107,7 @@
    "read_only": 1
   },
   {
+   "description": "Grace minutes consumed by this specific event.",
    "fieldname": "consumed_minutes",
    "fieldtype": "Int",
    "in_list_view": 1,
@@ -109,6 +119,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "description": "Grace remaining after consuming this event. When this hits 0, further late/early minutes generate a penalty.",
    "fieldname": "remaining_minutes",
    "fieldtype": "Int",
    "in_list_view": 1,
@@ -121,6 +132,7 @@
    "label": "Penalty"
   },
   {
+   "description": "Minutes that exceeded the available grace and were forwarded to a Discipline Penalty.",
    "fieldname": "penalty_minutes",
    "fieldtype": "Int",
    "in_list_view": 1,
@@ -155,12 +167,6 @@
    "fieldname": "error_log",
    "fieldtype": "Small Text",
    "label": "Error Log",
-   "read_only": 1
-  },
-  {
-   "fieldname": "date",
-   "fieldtype": "Date",
-   "label": "Date",
    "read_only": 1
   }
  ],

--- a/discipline_hr/discipline_hr/doctype/penalty_matrix/penalty_matrix.json
+++ b/discipline_hr/discipline_hr/doctype/penalty_matrix/penalty_matrix.json
@@ -12,6 +12,7 @@
  ],
  "fields": [
   {
+   "description": "Escalation tier &mdash; 1 = first violation in period, 2 = second, etc.",
    "fieldname": "violation_number",
    "fieldtype": "Int",
    "in_list_view": 1,
@@ -21,12 +22,13 @@
   },
   {
    "default": "0",
+   "description": "Decimal share of the daily rate to deduct. <code>1.0</code> = full day, <code>0.5</code> = half day.",
    "fieldname": "percentage",
    "fieldtype": "Float",
    "in_list_view": 1,
    "in_preview": 1,
    "label": "% of Daily Rate",
-   "placeholder": "0.25, 0.5, 1, 1.5",
+   "placeholder": "e.g., 0.5 = 50% of daily rate, 1.0 = 100%",
    "reqd": 1
   },
   {

--- a/discipline_hr/discipline_hr/number_card/penalties_this_month/penalties_this_month.json
+++ b/discipline_hr/discipline_hr/number_card/penalties_this_month/penalties_this_month.json
@@ -1,0 +1,22 @@
+{
+ "aggregate_function_based_on": "penalty_amount",
+ "creation": "2026-04-27 12:00:00.000000",
+ "docstatus": 0,
+ "doctype": "Number Card",
+ "document_type": "Discipline Penalty",
+ "dynamic_filters_json": "",
+ "filters_json": "[[\"Discipline Penalty\",\"status\",\"in\",[\"Auto Processed\",\"Processed\"],false],[\"Discipline Penalty\",\"violation_date\",\"Timespan\",\"this month\",false]]",
+ "function": "Sum",
+ "idx": 0,
+ "is_public": 1,
+ "is_standard": 1,
+ "label": "Penalties This Month",
+ "modified": "2026-04-27 12:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Discipline Hr",
+ "name": "Penalties This Month",
+ "owner": "Administrator",
+ "show_percentage_stats": 1,
+ "stats_time_interval": "Monthly",
+ "type": "Document Type"
+}

--- a/discipline_hr/discipline_hr/workspace/discipline_hr/discipline_hr.json
+++ b/discipline_hr/discipline_hr/workspace/discipline_hr/discipline_hr.json
@@ -1,6 +1,15 @@
 {
- "charts": [],
- "content": "[{\"id\":\"hYBo592y2A\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\" data--h-bstatus=\\\"0OBSERVED\\\">Discipline HR</span>\",\"col\":12}},{\"id\":\"dashboard-header\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h6 text-muted uppercase\\\" data--h-bstatus=\\\"0OBSERVED\\\">Dashboard</span>\",\"col\":12}},{\"id\":\"nc-pending-permissions\",\"type\":\"number_card\",\"data\":{\"number_card_name\":\"Pending Attendance Permissions\",\"col\":6}},{\"id\":\"nc-pending-penalty\",\"type\":\"number_card\",\"data\":{\"number_card_name\":\"Pending Discipline Penalty\",\"col\":6}},{\"id\":\"txn-header\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h6 text-muted uppercase\\\" data--h-bstatus=\\\"0OBSERVED\\\">Transactions</span>\",\"col\":12}},{\"id\":\"sc-attendance\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Attendance\",\"col\":4}},{\"id\":\"sc-permissions\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Attendance Permissions\",\"col\":4}},{\"id\":\"sc-penalty\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Discipline Penalty\",\"col\":4}},{\"id\":\"sc-ledger\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Employee Grace Ledger\",\"col\":4}},{\"id\":\"reports-header\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h6 text-muted uppercase\\\" data--h-bstatus=\\\"0OBSERVED\\\">Reports</span>\",\"col\":12}},{\"id\":\"sc-egl-report\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Employee Grace Ledger Report\",\"col\":3}},{\"id\":\"sc-ap-pipeline\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Attendance Permissions Pipeline\",\"col\":3}},{\"id\":\"sc-penalty-register\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Discipline Penalty Register\",\"col\":3}},{\"id\":\"sc-monthly-summary\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Monthly Penalty Summary\",\"col\":3}},{\"id\":\"cfg-header\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h6 text-muted uppercase\\\" data--h-bstatus=\\\"0OBSERVED\\\">Configuration</span>\",\"col\":12}},{\"id\":\"sc-policy\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Attendance Penalty Policy\",\"col\":4}},{\"id\":\"sc-absence-policy\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Absence Penalty Policy\",\"col\":4}},{\"id\":\"sc-shift\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Shift Type\",\"col\":4}},{\"id\":\"sc-settings\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Discipline Hr Settings\",\"col\":4}}]",
+ "charts": [
+  {
+   "chart_name": "Attendance Permissions Status",
+   "label": "Attendance Permissions Status"
+  },
+  {
+   "chart_name": "Discipline Penalty Status",
+   "label": "Discipline Penalty Status"
+  }
+ ],
+ "content": "[{\"id\": \"onboarding-header\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h6 text-muted uppercase\\\">Quick Start</span>\", \"col\": 12}}, {\"id\": \"onboarding-body\", \"type\": \"paragraph\", \"data\": {\"text\": \"<ol class=\\\"mb-4\\\"><li><b>Configure an Attendance Penalty Policy</b> &mdash; choose <i>Factor</i>, <i>Fixed Per Hour</i>, or <i>Penalty Matrix</i>. See <i>Configuration</i> below.</li><li><b>Open Discipline HR Settings</b> &mdash; pick the default policy and salary calculation basis (month days, salary basis).</li><li><b>Submit an Attendance</b> with late or early minutes &mdash; the pipeline creates an Attendance Permission, then a Discipline Penalty automatically.</li></ol>\", \"col\": 12}}, {\"id\": \"hYBo592y2A\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h4\\\" data--h-bstatus=\\\"0OBSERVED\\\">Discipline HR</span>\", \"col\": 12}}, {\"id\": \"dashboard-header\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h6 text-muted uppercase\\\" data--h-bstatus=\\\"0OBSERVED\\\">Dashboard</span>\", \"col\": 12}}, {\"id\": \"nc-pending-permissions\", \"type\": \"number_card\", \"data\": {\"number_card_name\": \"Pending Attendance Permissions\", \"col\": 4}}, {\"id\": \"nc-pending-penalty\", \"type\": \"number_card\", \"data\": {\"number_card_name\": \"Pending Discipline Penalty\", \"col\": 4}}, {\"id\": \"nc-penalties-this-month\", \"type\": \"number_card\", \"data\": {\"number_card_name\": \"Penalties This Month\", \"col\": 4}}, {\"id\": \"chart-permissions-status\", \"type\": \"chart\", \"data\": {\"chart_name\": \"Attendance Permissions Status\", \"col\": 6}}, {\"id\": \"chart-penalty-status\", \"type\": \"chart\", \"data\": {\"chart_name\": \"Discipline Penalty Status\", \"col\": 6}}, {\"id\": \"txn-header\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h6 text-muted uppercase\\\" data--h-bstatus=\\\"0OBSERVED\\\">Transactions</span>\", \"col\": 12}}, {\"id\": \"sc-attendance\", \"type\": \"shortcut\", \"data\": {\"shortcut_name\": \"Attendance\", \"col\": 4}}, {\"id\": \"sc-permissions\", \"type\": \"shortcut\", \"data\": {\"shortcut_name\": \"Attendance Permissions\", \"col\": 4}}, {\"id\": \"sc-penalty\", \"type\": \"shortcut\", \"data\": {\"shortcut_name\": \"Discipline Penalty\", \"col\": 4}}, {\"id\": \"sc-ledger\", \"type\": \"shortcut\", \"data\": {\"shortcut_name\": \"Employee Grace Ledger\", \"col\": 4}}, {\"id\": \"reports-header\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h6 text-muted uppercase\\\" data--h-bstatus=\\\"0OBSERVED\\\">Reports</span>\", \"col\": 12}}, {\"id\": \"sc-egl-report\", \"type\": \"shortcut\", \"data\": {\"shortcut_name\": \"Employee Grace Ledger Report\", \"col\": 3}}, {\"id\": \"sc-ap-pipeline\", \"type\": \"shortcut\", \"data\": {\"shortcut_name\": \"Attendance Permissions Pipeline\", \"col\": 3}}, {\"id\": \"sc-penalty-register\", \"type\": \"shortcut\", \"data\": {\"shortcut_name\": \"Discipline Penalty Register\", \"col\": 3}}, {\"id\": \"sc-monthly-summary\", \"type\": \"shortcut\", \"data\": {\"shortcut_name\": \"Monthly Penalty Summary\", \"col\": 3}}, {\"id\": \"cfg-header\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h6 text-muted uppercase\\\" data--h-bstatus=\\\"0OBSERVED\\\">Configuration</span>\", \"col\": 12}}, {\"id\": \"sc-policy\", \"type\": \"shortcut\", \"data\": {\"shortcut_name\": \"Attendance Penalty Policy\", \"col\": 4}}, {\"id\": \"sc-absence-policy\", \"type\": \"shortcut\", \"data\": {\"shortcut_name\": \"Absence Penalty Policy\", \"col\": 4}}, {\"id\": \"sc-shift\", \"type\": \"shortcut\", \"data\": {\"shortcut_name\": \"Shift Type\", \"col\": 4}}, {\"id\": \"sc-settings\", \"type\": \"shortcut\", \"data\": {\"shortcut_name\": \"Discipline Hr Settings\", \"col\": 4}}]",
  "creation": "2026-02-24 13:40:42.345311",
  "custom_blocks": [],
  "docstatus": 0,
@@ -14,7 +23,7 @@
  "is_standard": 1,
  "label": "Discipline Hr",
  "links": [],
- "modified": "2026-04-27 12:30:00.000000",
+ "modified": "2026-04-27 14:00:00.000000",
  "modified_by": "Administrator",
  "module": "Discipline Hr",
  "name": "Discipline Hr",
@@ -26,6 +35,10 @@
   {
    "label": "Pending Discipline Penalty",
    "number_card_name": "Pending Discipline Penalty"
+  },
+  {
+   "label": "Penalties This Month",
+   "number_card_name": "Penalties This Month"
   }
  ],
  "owner": "Administrator",

--- a/discipline_hr/events/attendance.py
+++ b/discipline_hr/events/attendance.py
@@ -269,6 +269,12 @@ def _should_create_absence_penalty(shift_doc, config):
 def cascade_cancel_attendance(doc, method=None):
     """Hard-delete all downstream discipline_hr docs when an Attendance is cancelled.
 
+    Wired to ``on_cancel`` only (not ``on_trash``). Cancellation is the user-visible
+    action that signals "remove the consequences of this Attendance" — running the
+    cascade here means HR sees penalties disappear at cancel time without needing a
+    follow-up delete. By the time ``on_trash`` would fire, every downstream record is
+    already gone and the cascade would be a no-op duplicate.
+
     Deletion order (leaf-first to respect link references):
       1. Additional Salary  (cancel if submitted, then delete)
       2. Discipline Penalty

--- a/discipline_hr/hooks.py
+++ b/discipline_hr/hooks.py
@@ -148,7 +148,6 @@ doc_events = {
             "discipline_hr.events.attendance.create_absence_penalty",
         ],
         "on_cancel": "discipline_hr.events.attendance.cascade_cancel_attendance",
-        "on_trash": "discipline_hr.events.attendance.cascade_cancel_attendance",
     },
     "Salary Slip": {
         "validate": [

--- a/discipline_hr/services/attendance_permission.py
+++ b/discipline_hr/services/attendance_permission.py
@@ -184,7 +184,10 @@ def _create_attendance_penalty(ctx: _AttendanceContext, ledger, config):
         )
         return
 
-    if frappe.db.exists("Discipline Penalty", {"attendance": ctx.attendance}):
+    if frappe.db.exists(
+        "Discipline Penalty",
+        {"attendance": ctx.attendance, "docstatus": ("!=", 2)},
+    ):
         _log(
             "info",
             "duplicate_discipline_penalty",


### PR DESCRIPTION
## Summary

Lands the lower-risk subset of the pre-open-source design review in `~/.claude/plans/review-the-overall-app-fizzy-meerkat.md`. Four findings closed; two architectural fixes deferred to follow-up issues per direction during the session.

## What landed

| Finding | Severity | Fix |
|---|---|---|
| #5 cascade-cancel runs twice | red | Drop `on_trash` hook; document the choice. `on_cancel` is the user-visible action that signals "remove the consequences" — also matches the function's name. |
| #6 duplicate-guard ignores cancelled penalties | red | Filter `docstatus != 2` so retry paths can replace a deliberately-cancelled penalty. |
| #2 SSA query ignores `from_date` | red | Filter `from_date <= violation_date` so retroactive raises do not silently rewrite past-period penalty amounts. |
| #8 AS retry guard ignores cancelled / stuck-draft AS | yellow | Cancelled AS no longer trips the guard; a stuck draft AS is now submitted on retry instead of silently skipped. |

## Deliberately deferred (filed as follow-up issues)

- **#3 freeze `penalty_amount` on submit / when AS exists** — needs design decision around HR's ability to correct.
- **#1 atomic grace ledger consumption (redis lock / Grace Period doctype)** — pairs with the rollover redesign per Q2 of the audit.

## Test plan
- [x] `bench --site capital run-tests --app discipline_hr` — 69/69 pass
- [x] New unit tests cover: SSA `from_date` filter shape, cancelled-AS guard branch, draft-AS retry submit branch
- [ ] Manual verification of cascade-cancel hook firing exactly once on Attendance deletion (out of session — recommend smoke-test before merge)
- [ ] Manual retro-raise verification: insert SSA with `from_date > violation_date`, confirm penalty amount unchanged

## Out of scope
- Multi-company hardening (Q1 — deferred to v2.0)
- Grace Period doctype + rollover redesign (Q2 — large architectural change, separate issue)
- Salary slip bypass field (Q4 — separate issue)
- 🟡 / 🔵 hardening items from the audit (separate issue cluster)